### PR TITLE
Add homecoachs API endpoint

### DIFF
--- a/examples/get_homecoachs_data.rs
+++ b/examples/get_homecoachs_data.rs
@@ -1,0 +1,41 @@
+use netatmo_rs::{ClientCredentials, Netatmo, NetatmoClient, Scope};
+use std::env;
+
+fn main() {
+    env_logger::init();
+
+    let client_id = env::var_os("NETATMO_CLIENT_ID")
+        .expect("Environment variable 'NETATMO_CLIENT_ID' is not set.")
+        .to_string_lossy()
+        .to_string();
+    let client_secret = env::var_os("NETATMO_CLIENT_SECRET")
+        .expect("Environment variable 'NETATMO_CLIENT_SECRET' is not set.")
+        .to_string_lossy()
+        .to_string();
+    let username = env::var_os("NETATMO_USERNAME")
+        .expect("Environment variable 'NETATMO_USERNAME' is not set.")
+        .to_string_lossy()
+        .to_string();
+    let password = env::var_os("NETATMO_PASSWORD")
+        .expect("Environment variable 'NETATMO_PASSWORD' is not set.")
+        .to_string_lossy()
+        .to_string();
+    let device_id = env::var_os("NETATMO_DEVICE_ID")
+        .expect("Environment variable 'NETATMO_DEVICE_ID' is not set")
+        .to_string_lossy()
+        .to_string();
+
+    let client_credentials = ClientCredentials {
+        client_id: &client_id,
+        client_secret: &client_secret,
+    };
+    let scopes = vec![Scope::ReadHomecoach];
+
+    let homecoachs_data = NetatmoClient::new(&client_credentials)
+        .authenticate(&username, &password, &scopes)
+        .expect("Failed to authenticate")
+        .get_homecoachs_data(&device_id)
+        .expect("Failed to get home coach data");
+
+    println!("{:#?}", homecoachs_data);
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -25,6 +25,7 @@ pub trait Netatmo {
     fn get_home_status(&self, parameters: &get_home_status::Parameters) -> Result<HomeStatus>;
     fn get_homes_data(&self, parameters: &get_homes_data::Parameters) -> Result<HomesData>;
     fn get_station_data(&self, device_id: &str) -> Result<StationData>;
+    fn get_homecoachs_data(&self, device_id: &str) -> Result<StationData>;
     fn get_measure(&self, parameters: &get_measure::Parameters) -> Result<Measure>;
     fn set_room_thermpoint(
         &self,
@@ -180,6 +181,10 @@ impl Netatmo for AuthenticatedClient {
 
     fn get_station_data(&self, device_id: &str) -> Result<StationData> {
         get_station_data::get_station_data(&self, device_id)
+    }
+
+    fn get_homecoachs_data(&self, device_id: &str) -> Result<StationData> {
+        get_station_data::get_homecoachs_data(self, device_id)
     }
 
     fn get_measure(&self, parameters: &get_measure::Parameters) -> Result<Measure> {


### PR DESCRIPTION
This PR adds support for the `gethomecoachsdata` API.

Because the API is almost identical to the `getstationsdata` API, I amended `Device` from `src/client/get_station_data.rs` slightly to make it support both APIs.